### PR TITLE
Add create chat completion (#12)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,9 @@ subprojects {
 		implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 		implementation("org.jetbrains.kotlin:kotlin-reflect")
 
+		// https://mvnrepository.com/artifact/io.netty/netty-resolver-dns-native-macos/4.1.92.Final
+		implementation("io.netty:netty-resolver-dns-native-macos:4.1.92.Final:osx-aarch_64")
+
 		// kotest
 		// https://kotest.io/docs/quickstart
 		testImplementation("io.kotest:kotest-runner-junit5:${kotestVersion}")
@@ -97,6 +100,7 @@ project(":api") {
 
 project(":client") {
 	dependencies {
+		implementation("org.springframework.boot:spring-boot-starter-webflux")
 	}
 
 	val jar: Jar by tasks

--- a/client/src/main/kotlin/team/backend/client/OpenAiClient.kt
+++ b/client/src/main/kotlin/team/backend/client/OpenAiClient.kt
@@ -1,0 +1,30 @@
+package team.backend.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+import team.backend.dto.ChatDto
+import team.backend.properties.OpenAiProperties
+
+@Component
+class OpenAiClient(
+    private val openAiProperties: OpenAiProperties,
+    private val objectMapper: ObjectMapper,
+) {
+
+    private val webClient = WebClient.builder()
+        .baseUrl(openAiProperties.endpoint.base)
+        .build()
+
+    fun chat(body: ChatDto.Request): Mono<ChatDto.Response> {
+        return webClient.post()
+            .uri(openAiProperties.endpoint.chat)
+            .contentType(MediaType.APPLICATION_JSON)
+            .header("Authorization", "Bearer ${openAiProperties.token}")
+            .bodyValue(objectMapper.writeValueAsString(body))
+            .retrieve()
+            .bodyToMono(ChatDto.Response::class.java)
+    }
+}

--- a/client/src/main/kotlin/team/backend/dto/ChatDto.kt
+++ b/client/src/main/kotlin/team/backend/dto/ChatDto.kt
@@ -1,25 +1,22 @@
 package team.backend.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import team.backend.model.ChatModel
+import team.backend.model.ChatRole
 
 class ChatDto {
-
-    companion object {
-        private const val chatModel = "gpt-3.5-turbo"
-        private const val chatRole = "user"
-    }
 
     data class Request(
         val model: String,
         val messages: List<Message>
     ) {
         companion object {
-            fun from(content: String): Request {
+            fun of(model: ChatModel, role: ChatRole, content: String): Request {
                 return Request(
-                    model = chatModel,
+                    model = model.key,
                     messages = listOf(
                         Message(
-                            role = chatRole,
+                            role = role.key,
                             content = content
                         )
                     )

--- a/client/src/main/kotlin/team/backend/dto/ChatDto.kt
+++ b/client/src/main/kotlin/team/backend/dto/ChatDto.kt
@@ -1,0 +1,57 @@
+package team.backend.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+class ChatDto {
+
+    companion object {
+        private const val chatModel = "gpt-3.5-turbo"
+        private const val chatRole = "user"
+    }
+
+    data class Request(
+        val model: String,
+        val messages: List<Message>
+    ) {
+        companion object {
+            fun from(content: String): Request {
+                return Request(
+                    model = chatModel,
+                    messages = listOf(
+                        Message(
+                            role = chatRole,
+                            content = content
+                        )
+                    )
+                )
+            }
+        }
+    }
+
+    data class Response(
+        val id: String,
+        val `object`: String,
+        val created: Long,
+        val choices: List<Choice>,
+        val usage: Usage
+    )
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    data class Message(
+        val role: String,
+        val content: String,
+        val name: String? = null
+    )
+
+    data class Choice(
+        val index: Int,
+        val message: Message,
+        val finish_reason: String
+    )
+
+    data class Usage(
+        val prompt_tokens: Int,
+        val completion_tokens: Int,
+        val total_tokens: Int
+    )
+}

--- a/client/src/main/kotlin/team/backend/dto/ChatDto.kt
+++ b/client/src/main/kotlin/team/backend/dto/ChatDto.kt
@@ -1,6 +1,8 @@
 package team.backend.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
 import team.backend.model.ChatModel
 import team.backend.model.ChatRole
 
@@ -40,15 +42,17 @@ class ChatDto {
         val name: String? = null
     )
 
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
     data class Choice(
         val index: Int,
         val message: Message,
-        val finish_reason: String
+        val finishReason: String
     )
 
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
     data class Usage(
-        val prompt_tokens: Int,
-        val completion_tokens: Int,
-        val total_tokens: Int
+        val promptTokens: Int,
+        val completionTokens: Int,
+        val totalTokens: Int
     )
 }

--- a/client/src/main/kotlin/team/backend/model/ChatModel.kt
+++ b/client/src/main/kotlin/team/backend/model/ChatModel.kt
@@ -1,0 +1,8 @@
+package team.backend.model
+
+enum class ChatModel(
+    val key: String
+) {
+    GPT40TURBO("gpt-4"),
+    GPT35TURBO("gpt-3.5-turbo"),
+}

--- a/client/src/main/kotlin/team/backend/model/ChatRole.kt
+++ b/client/src/main/kotlin/team/backend/model/ChatRole.kt
@@ -1,0 +1,9 @@
+package team.backend.model
+
+enum class ChatRole(
+    val key: String
+) {
+    SYSTEM("system"),
+    USER("user"),
+    ASSISTANT("assistant")
+}

--- a/client/src/main/kotlin/team/backend/properties/OpenAiProperties.kt
+++ b/client/src/main/kotlin/team/backend/properties/OpenAiProperties.kt
@@ -1,0 +1,17 @@
+package team.backend.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@ConfigurationProperties(prefix = "openai")
+data class OpenAiProperties(
+    var endpoint: Endpoint = Endpoint(),
+    var token: String = ""
+) {
+
+    data class Endpoint(
+        var base: String = "",
+        var chat: String = ""
+    )
+}


### PR DESCRIPTION
## Related Issue
- #12 

## Description
- I'm add webflux dependency in client module for using webclient
- configuration contents in OpenAiProperties
- chat api implementation in OpenAiClient
- I'll add yml with next issue

## References
- https://platform.openai.com/docs/api-reference/chat/create

