### PR TITLE
Add CommonResponse, ResponseCode (#19)

### DIFF
--- a/api/src/main/kotlin/team/backend/common/response/CommonResponse.kt
+++ b/api/src/main/kotlin/team/backend/common/response/CommonResponse.kt
@@ -1,0 +1,40 @@
+package team.backend.common.response
+
+class CommonResponse<T> private constructor(
+    val code: String,
+    val message: String,
+    val payload: T? = null
+){
+
+    companion object {
+
+        fun success(): CommonResponse<Unit> {
+            return CommonResponse(
+                code = ResponseCode.SUCCESS.code,
+                message = ResponseCode.SUCCESS.message
+            )
+        }
+
+        fun <T> success(payload: T): CommonResponse<T> {
+            return CommonResponse(
+                code = ResponseCode.SUCCESS.code,
+                message = ResponseCode.SUCCESS.message,
+                payload = payload
+            )
+        }
+
+        fun fail(): CommonResponse<Unit> {
+            return CommonResponse(
+                code = ResponseCode.INTERNAL_SERVER_ERROR.code,
+                message = ResponseCode.INTERNAL_SERVER_ERROR.message
+            )
+        }
+
+        fun fail(responseCode: ResponseCode): CommonResponse<Unit> {
+            return CommonResponse(
+                code = responseCode.code,
+                message = responseCode.message
+            )
+        }
+    }
+}

--- a/api/src/main/kotlin/team/backend/common/response/ResponseCode.kt
+++ b/api/src/main/kotlin/team/backend/common/response/ResponseCode.kt
@@ -1,0 +1,14 @@
+package team.backend.common.response
+
+import org.springframework.http.HttpStatus
+
+enum class ResponseCode(
+    val code: String,
+    val message: String,
+    val httpStatus: HttpStatus
+) {
+
+    SUCCESS("100", "SUCCESS", HttpStatus.OK),
+    INTERNAL_SERVER_ERROR("101", "INTERNAL_SERVER_ERROR", HttpStatus.INTERNAL_SERVER_ERROR),
+    INVALID_DOMAIN("102", "INVALID DOMAIN", HttpStatus.BAD_REQUEST)
+}


### PR DESCRIPTION
## Related Issue
- close #19 

## Description

### Make Common Response
- prevented to generate constructor outside and implemented with a static methods.
```
{
  "code": String,
  "message": String,
  "payload": T
}
```
### Make Custom ResponseCode
- implemented some custom common responseCode.
```
{
  "code": String,
  "message": String,
  "httpStatus": HttpStatus
}
```

## Think

### Custom ResponseCode
- it's good to manage messages flexibly by importing them from DB later
