### PR TITLE
Logging Configuration (#31)

### DIFF
--- a/api/src/main/kotlin/team/backend/common/logging/LoggingFilter.kt
+++ b/api/src/main/kotlin/team/backend/common/logging/LoggingFilter.kt
@@ -1,0 +1,37 @@
+package team.backend.common.logging
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.http.server.reactive.ServerHttpRequest
+import org.springframework.http.server.reactive.ServerHttpResponse
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ServerWebExchange
+import org.springframework.web.server.ServerWebExchangeDecorator
+import org.springframework.web.server.WebFilter
+import org.springframework.web.server.WebFilterChain
+import reactor.core.publisher.Mono
+import team.backend.common.logging.decorator.LoggingRequestDecorator
+import team.backend.common.logging.decorator.LoggingResponseDecorator
+
+@Component
+class LoggingFilter: WebFilter {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> =
+        chain.filter(LoggingWebExchange(log, exchange))
+}
+
+class LoggingWebExchange(log: Logger, delegate: ServerWebExchange) : ServerWebExchangeDecorator(delegate) {
+    // Encapsulate the logic of logging by Decorators
+    private val requestDecorator: LoggingRequestDecorator = LoggingRequestDecorator(log, delegate.request)
+    private val responseDecorator: LoggingResponseDecorator = LoggingResponseDecorator(log, delegate.response)
+
+    override fun getRequest(): ServerHttpRequest {
+        return requestDecorator
+    }
+
+    override fun getResponse(): ServerHttpResponse {
+        return responseDecorator
+    }
+}

--- a/api/src/main/kotlin/team/backend/common/logging/decorator/LoggingRequestDecorator.kt
+++ b/api/src/main/kotlin/team/backend/common/logging/decorator/LoggingRequestDecorator.kt
@@ -24,7 +24,9 @@ class LoggingRequestDecorator internal constructor(log: Logger, delegate: Server
         if (log.isInfoEnabled) {
             val path = delegate.uri.path
             val query = delegate.uri.query
-            val method = Optional.ofNullable(delegate.method).orElse(HttpMethod.GET).name()
+            val method = Optional.ofNullable(delegate.method)
+                .map { it.name() }
+                .orElse("NONE")
             val headers = delegate.headers.asString()
             log.info(
                 "{} {}\n {}", method, path + (if (StringUtils.hasText(query)) "?$query" else ""), headers

--- a/api/src/main/kotlin/team/backend/common/logging/decorator/LoggingRequestDecorator.kt
+++ b/api/src/main/kotlin/team/backend/common/logging/decorator/LoggingRequestDecorator.kt
@@ -1,0 +1,41 @@
+package team.backend.common.logging.decorator
+
+import org.slf4j.Logger
+import org.springframework.core.io.buffer.DataBuffer
+import org.springframework.http.HttpMethod
+import org.springframework.http.server.reactive.ServerHttpRequest
+import org.springframework.http.server.reactive.ServerHttpRequestDecorator
+import org.springframework.util.StringUtils
+import reactor.core.publisher.Flux
+import team.backend.support.asString
+import java.io.ByteArrayOutputStream
+import java.nio.channels.Channels
+import java.util.*
+
+class LoggingRequestDecorator internal constructor(log: Logger, delegate: ServerHttpRequest): ServerHttpRequestDecorator(delegate) {
+
+    private val body: Flux<DataBuffer>?
+
+    override fun getBody(): Flux<DataBuffer> {
+        return body!!
+    }
+
+    init {
+        if (log.isInfoEnabled) {
+            val path = delegate.uri.path
+            val query = delegate.uri.query
+            val method = Optional.ofNullable(delegate.method).orElse(HttpMethod.GET).name()
+            val headers = delegate.headers.asString()
+            log.info(
+                "{} {}\n {}", method, path + (if (StringUtils.hasText(query)) "?$query" else ""), headers
+            )
+            body = super.getBody().doOnNext { buffer: DataBuffer ->
+                val bodyStream = ByteArrayOutputStream()
+                Channels.newChannel(bodyStream).write(buffer.asByteBuffer().asReadOnlyBuffer())
+                log.info("{}: {}", ">>> Request", String(bodyStream.toByteArray()))
+            }
+        } else {
+            body = super.getBody()
+        }
+    }
+}

--- a/api/src/main/kotlin/team/backend/common/logging/decorator/LoggingResponseDecorator.kt
+++ b/api/src/main/kotlin/team/backend/common/logging/decorator/LoggingResponseDecorator.kt
@@ -1,0 +1,28 @@
+package team.backend.common.logging.decorator
+
+import org.reactivestreams.Publisher
+import org.slf4j.Logger
+import org.springframework.core.io.buffer.DataBuffer
+import org.springframework.http.server.reactive.ServerHttpResponse
+import org.springframework.http.server.reactive.ServerHttpResponseDecorator
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import team.backend.support.asString
+import java.io.ByteArrayOutputStream
+import java.nio.channels.Channels
+
+class LoggingResponseDecorator internal constructor(val log: Logger, delegate: ServerHttpResponse): ServerHttpResponseDecorator(delegate) {
+
+    override fun writeWith(body: Publisher<out DataBuffer>): Mono<Void> {
+        return super.writeWith(
+            Flux.from(body)
+                .doOnNext { buffer: DataBuffer ->
+                    if (log.isInfoEnabled) {
+                        val bodyStream = ByteArrayOutputStream()
+                        Channels.newChannel(bodyStream).write(buffer.asByteBuffer().asReadOnlyBuffer())
+                        log.info("{}: {} - {} : {}", "<<< Response", String(bodyStream.toByteArray()),
+                            "header", delegate.headers.asString())
+                    }
+                })
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,8 @@ subprojects {
 
 		implementation(Netty.DNS_RESOLVER_MACOS)
 
+		implementation(Logging.LOG_STASH_ENCODER)
+
 		addDatabaseDependencies()
 
 		testImplementation(Kotest.RUNNER_JUNIT)
@@ -121,8 +123,15 @@ project(Modules.API) {
 		into(Resources.SWAGGER_DESTINATION_PATH)
 	}
 
+	tasks.register<Copy>("copyLogXml") {
+		from(Resources.LOGGING_SOURCE_PATH) {
+			include("/**")
+		}
+		into(Resources.LOGGING_DESTINATION_PATH)
+	}
+
 	tasks.named("compileJava") {
-		dependsOn("copySecretYml", "copySecretSwagger")
+		dependsOn("copySecretYml", "copySecretSwagger", "copyLogXml")
 	}
 
 	tasks.register<Copy>("copyOasToSwagger") {

--- a/buildSrc/src/main/kotlin/Dependency.kt
+++ b/buildSrc/src/main/kotlin/Dependency.kt
@@ -65,4 +65,8 @@ object Documentation {
     const val EPAGES_RESTDOCS_API_SPEC_WEBCLIENT = "com.epages:restdocs-api-spec-webtestclient:${Versions.EPAGES}"
 }
 
+object Logging {
+    const val LOG_STASH_ENCODER = "net.logstash.logback:logstash-logback-encoder:${Versions.LOG_STASH_ENCODER}"
+}
+
 const val JUNIT = "junit"

--- a/buildSrc/src/main/kotlin/Utils.kt
+++ b/buildSrc/src/main/kotlin/Utils.kt
@@ -18,4 +18,6 @@ object Resources {
     const val YML_DESTINATION_PATH = "./src/main/resources"
     const val SWAGGER_SOURCE_PATH = "../chaterview-private/swagger"
     const val SWAGGER_DESTINATION_PATH = "./src/main/resources/static"
+    const val LOGGING_SOURCE_PATH = "../chaterview-private/logging"
+    const val LOGGING_DESTINATION_PATH = "./src/main/resources/logging"
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -17,6 +17,9 @@ object Versions {
     // Netty
     const val NETTY_DNS_RESOLVER_MACOS = "4.1.92.Final"
 
+    // Logging
+    const val LOG_STASH_ENCODER = "7.3"
+
     // Docs
     const val EPAGES = "0.18.0"
 

--- a/core/src/main/kotlin/team/backend/support/HttpHeadersExtension.kt
+++ b/core/src/main/kotlin/team/backend/support/HttpHeadersExtension.kt
@@ -1,0 +1,16 @@
+package team.backend.support
+
+import org.springframework.http.HttpHeaders
+import java.util.stream.Collectors
+
+fun HttpHeaders.asString(): String {
+    return entries
+        .stream()
+        .map { entry: Map.Entry<String, List<String?>?> ->
+            " ${entry.key}: [" + java.lang.String.join(
+                ";",
+                entry.value
+            ) + "]"
+        }
+        .collect(Collectors.joining("\n"))
+}


### PR DESCRIPTION
## Related Issue
- close #31 

## Description

- Request, Response Log Configuration

__Outputs:__

```
// Request
{"@timestamp":"2023-05-21T13:44:16.125337+09:00","@version":"1","message":">>> Request: {\n    \"jobName\": \"1234\"\n}","logger_name":"team.backend.common.logging.LoggingFilter","thread_name":"reactor-http-nio-3","level":"DEBUG","level_value":10000}

// Response
{"@timestamp":"2023-05-21T13:44:16.272728+09:00","@version":"1","message":"<<< Response: {\"id\":1,\"jobName\":\"Backend Developer\"} - header :  transfer-encoding: [chunked]\n Content-Type: [application/json]\n Content-Length: [38]","logger_name":"team.backend.common.logging.LoggingFilter","thread_name":"vert.x-eventloop-thread-1","level":"DEBUG","level_value":10000}
```

## References

- https://www.baeldung.com/kotlin/spring-webflux-log-request-response-body

